### PR TITLE
Support empty paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ set(tayweeargs_INCLUDE "${SOURCE_DIR}")
 
 # gfakluge (header only)
 ExternalProject_Add(gfakluge
-  GIT_REPOSITORY "https://github.com/glennhickey/gfakluge.git"
-  GIT_TAG "d6a1cc1f9440e167e4e435a5f832467c5e37a039"
+  GIT_REPOSITORY "https://github.com/vgteam/gfakluge.git"
+  GIT_TAG "99f70b0d832cfb3439568e2494efacd1079e6a09"
   BUILD_IN_SOURCE TRUE
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
   UPDATE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ set(tayweeargs_INCLUDE "${SOURCE_DIR}")
 
 # gfakluge (header only)
 ExternalProject_Add(gfakluge
-  GIT_REPOSITORY "https://github.com/vgteam/gfakluge.git"
-  GIT_TAG "d99d927ab286c3dfaeb4db15c15d306d1fab0806"
+  GIT_REPOSITORY "https://github.com/glennhickey/gfakluge.git"
+  GIT_TAG "d6a1cc1f9440e167e4e435a5f832467c5e37a039"
   BUILD_IN_SOURCE TRUE
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
   UPDATE_COMMAND ""

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -573,13 +573,15 @@ void XG::from_gfa(const std::string& gfa_filename, bool validate, std::string ba
     };
     auto for_each_path_element = [&](const std::function<void(const std::string& path_name,
                                                               const nid_t& node_id, const bool& is_rev,
-                                                              const std::string& cigar)>& lambda) {
+                                                              const std::string& cigar,
+                                                              bool is_empty)>& lambda) {
         gfa.for_each_path_element_in_file(filename, [&](const std::string& path_name_raw, const std::string& node_id_str,
-                                                        bool is_rev, const std::string& cigar) {
+                                                        bool is_rev, const std::string& cigar,
+                                                        bool is_empty) {
             nid_t node_id = std::stol(node_id_str);
             std::string path_name = path_name_raw;
             path_name.erase(std::remove_if(path_name.begin(), path_name.end(), [](char c) { return std::isspace(c); }), path_name.end());
-            lambda(path_name, node_id, is_rev, cigar);
+            lambda(path_name, node_id, is_rev, cigar, is_empty);
         });
     };
     from_enumerators(for_each_sequence, for_each_edge, for_each_path_element, validate, basename);
@@ -603,7 +605,7 @@ void XG::from_handle_graph(const HandleGraph& graph) {
     };
     auto for_each_path_element = [&](const std::function<void(const std::string& path_name,
                                                               const nid_t& node_id, const bool& is_rev,
-                                                              const std::string& cigar)>& lambda) {
+                                                              const std::string& cigar, bool is_empty)>& lambda) {
         // no-op
     };
     from_enumerators(for_each_sequence, for_each_edge, for_each_path_element, false);
@@ -626,13 +628,18 @@ void XG::from_path_handle_graph(const PathHandleGraph& graph) {
     };
     auto for_each_path_element = [&](const std::function<void(const std::string& path_name,
                                                               const nid_t& node_id, const bool& is_rev,
-                                                              const std::string& cigar)>& lambda) {
+                                                              const std::string& cigar, bool is_empty)>& lambda) {
         graph.for_each_path_handle([&](const path_handle_t& path_handle) {
                 std::string path_name = get_path_name(path_handle);
+                size_t step_count = 0;
                 graph.for_each_step_in_path(path_handle, [&](const step_handle_t& step) {
                         handle_t handle = graph.get_handle_of_step(step);
-                        lambda(path_name, graph.get_id(handle), graph.get_is_reverse(handle), "");
+                        lambda(path_name, graph.get_id(handle), graph.get_is_reverse(handle), "", false);
+                        ++step_count;
                     });
+                if (step_count == 0) {
+                    lambda(path_name, 0, false, "", true);
+                }
             });
     };
     from_enumerators(for_each_sequence, for_each_edge, for_each_path_element, false);
@@ -643,7 +650,7 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
                                                                             const nid_t& to, const bool& to_rev)>&)>& for_each_edge,
                           const std::function<void(const std::function<void(const std::string& path_name,
                                                                             const nid_t& node_id, const bool& is_rev,
-                                                                            const std::string& cigar)>&)>& for_each_path_element,
+                                                                            const std::string& cigar, bool is_empty)>&)>& for_each_path_element,
                           bool validate, std::string basename) {
 
     if (basename.empty()) {
@@ -678,7 +685,7 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
 #ifdef VERBOSE_DEBUG
     cerr << "counting paths" << endl;
 #endif
-    for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar) {
+    for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar, bool is_empty) {
             if (path_name != pname) {
                 ++path_count;
             }
@@ -873,7 +880,6 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
 
     auto build_accumulated_path = [&](void) {
         // only build if we had a path to build
-        if (curr_path_steps.empty()) return;
 #ifdef VERBOSE_DEBUG
         if (++p % 100 == 0) std::cerr << p << " of " << path_count << " ~ " << (float)p/(float)path_count * 100 << "%" << "\r";
 #endif
@@ -887,17 +893,23 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
 
     // todo ... is it circular?
     // might make sense to scan the file for this
-    for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar) {
+    bool has_path = false;
+    for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar, bool is_empty) {
             if (path_name != curr_path_name && !curr_path_name.empty()) {
                 // build the last path we've accumulated
                 build_accumulated_path();
                 curr_path_steps.clear();
             }
             curr_path_name = path_name;
-            curr_path_steps.push_back(get_handle(node_id, is_rev));
+            if (!is_empty) {
+                curr_path_steps.push_back(get_handle(node_id, is_rev));
+            }
+            has_path = true;
         });
     // build the last path
-    build_accumulated_path();
+    if (has_path) {
+        build_accumulated_path();
+    }
     curr_path_steps.clear();
 #ifdef VERBOSE_DEBUG
     std::cerr << path_count << " of " << path_count << " ~ 100.0000%" << std::endl;
@@ -1051,14 +1063,16 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
                 pos += get_length(handle);
             }
         };
-        for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar) {
+        for_each_path_element([&](const std::string& path_name, const nid_t& node_id, const bool& is_rev, const std::string& cigar, bool is_empty) {
                 if (path_name != curr_path_name && !curr_path_name.empty()) {
                     // check the last path we've accumulated
                     check_accumulated_path();
                     curr_path_steps.clear();
                 }
                 curr_path_name = path_name;
-                curr_path_steps.push_back(get_handle(node_id, is_rev));
+                if (!is_empty) {
+                    curr_path_steps.push_back(get_handle(node_id, is_rev));
+                }
             });
         // check the last path
         check_accumulated_path();

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -205,7 +205,7 @@ public:
                                                                             const nid_t& to, const bool& to_rev)>&)>& for_each_edge,
                           const std::function<void(const std::function<void(const std::string& path_name,
                                                                             const nid_t& node_id, const bool& is_rev,
-                                                                            const std::string& cigar)>&)>& for_each_path_element,
+                                                                            const std::string& cigar, bool is_empty)>&)>& for_each_path_element,
                           bool validate = false, std::string basename = "");
 
     /// Use a memory-mapped GFA file to build the index in low memory


### PR DESCRIPTION
Done by adding a new `is_empty` flag to the path element enumeration callback.  

Thought about adding some way of checking via node-id or cigar string, but thought it was safer to go with the extra flag.  

