### PR TITLE
Fix dangling file descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,8 @@ set(sdsl-lite-divsufsort_LIB "${INSTALL_DIR}/src/sdsl-lite-build/external/libdiv
 
 # mmmultimap (memory mapped multimap)
 ExternalProject_Add(mmmultimap
-  GIT_REPOSITORY "https://github.com/ekg/mmmultimap.git"
-  GIT_TAG "b92a5c8826141d61413546278719724e0f612c39"
+  GIT_REPOSITORY "https://github.com/glennhickey/mmmultimap.git"
+  GIT_TAG "1a4247189c555fd58d9f70a03c7288f9a08e858e"
   BUILD_COMMAND ""
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -936,7 +936,7 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
     sdsl::util::assign(pn_bv_select, sdsl::bit_vector::select_1_type(&pn_bv));
     
     // is this file removed by construct?
-    string path_name_file = "@pathnames.iv";
+    string path_name_file = temp_file::create() + "@pathnames.iv";
     sdsl::store_to_file((const char*)path_names.c_str(), path_name_file);
     sdsl::construct(pn_csa, path_name_file, 1);
 


### PR DESCRIPTION
Resolves #13 by way of patch to mmmultimap submodule.  

note that gfakluge is leaving some danglign descriptors as well, which this does not resolve.  