### PR TITLE
Instrument stuff that travis doesn't like

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -413,15 +413,18 @@ XGPath::XGPath(const std::string& path_name,
     size_t positions_off = 0;
     size_t path_length = 0;
     // Start out with the max integer, as a handle, as our minimum-valued handle in the path.
-    min_handle = as_handle(std::numeric_limits<uint64_t>::max());
+    uint64_t min_handle_int = (path.size() ? as_integer(path[0]) : 0);
 
     // determine min handle value which occurs
-    for (size_t i = 0; i < path.size(); ++i) {
-        min_handle = as_handle(std::min(as_integer(min_handle), as_integer(path[i])));
+    for (size_t i = 1; i < path.size(); ++i) {
+        if (as_integer(path[i]) < min_handle_int) {
+            min_handle_int = as_integer(path[i]);
+        }
     }
+    min_handle = as_handle(min_handle_int);
 
 #ifdef debug_path_index
-    std::cerr << "Basing on minimum handle value " << as_integer(min_handle) << std::endl;
+    std::cerr << "Basing on minimum handle value " << as_integer(min_handle) << " (aka " << min_handle_int << ")" << std::endl;
 #endif
     
     // determine total length and record handles

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1913,6 +1913,12 @@ size_t XG::get_position_of_step(const step_handle_t& step) const {
 
 /// Get the step at a given position
 step_handle_t XG::get_step_at_position(const path_handle_t& path, const size_t& position) const {
+    
+    if (position >= get_path_length(path)) {
+        throw runtime_error("Cannot get position " + std::to_string(position) + " along path " +
+            get_path_name(path) + " of length " + std::to_string(get_path_length(path)));
+    }
+    
     const auto& xgpath = *paths[as_integer(path) - 1];
     step_handle_t step;
     as_integers(step)[0] = as_integer(path);

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -330,7 +330,7 @@ void XGPath::load_from_old_version(std::istream& in, uint32_t file_version, cons
             sdsl::sd_vector<> directions;
             directions.load(in);
             // compute the minimum handle
-            min_handle = handlegraph::as_handle(numeric_limits<int64_t>::max());
+            min_handle = handlegraph::as_handle(numeric_limits<uint64_t>::max());
             for (size_t i = 0; i < ids.size(); ++i) {
                 min_handle = as_handle(min(as_integer(min_handle),
                                            as_integer(graph.get_handle(ids[i] + id_offset - 1, directions[i]))));
@@ -413,7 +413,7 @@ XGPath::XGPath(const std::string& path_name,
     size_t positions_off = 0;
     size_t path_length = 0;
     // Start out with the max integer, as a handle, as our minimum-valued handle in the path.
-    min_handle = as_handle(std::numeric_limits<int64_t>::max());
+    min_handle = as_handle(std::numeric_limits<uint64_t>::max());
 
     // determine min handle value which occurs
     for (size_t i = 0; i < path.size(); ++i) {
@@ -421,7 +421,7 @@ XGPath::XGPath(const std::string& path_name,
     }
 
 #ifdef debug_path_index
-        std::cerr << "Basing on minimum handle value " << as_integer(min_handle) << std::endl;
+    std::cerr << "Basing on minimum handle value " << as_integer(min_handle) << std::endl;
 #endif
     
     // determine total length and record handles
@@ -697,7 +697,7 @@ void XG::from_enumerators(const std::function<void(const std::function<void(cons
     seq_length = 0;
     edge_count = 0;
     path_count = 0;
-    min_id = std::numeric_limits<int64_t>::max();
+    min_id = std::numeric_limits<uint64_t>::max();
     max_id = 0;
     // get information about graph size and id ranges
 #ifdef VERBOSE_DEBUG

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -547,6 +547,15 @@ size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std
     
 }
 
+void XG::dump_to_stream(std::ostream& out) const {
+    out << "===BEGIN XG===" << std::endl;
+    out << "index\tg\tbv" << std::endl;
+    for (size_t i = 0; i < g_iv.size(); i++) {
+        out << i << "\t" << g_iv[i] << "\t" << g_bv[i] << std::endl;
+    }
+    out << "===END XG===" << std::endl;
+}
+
 void XG::from_gfa(const std::string& gfa_filename, bool validate, std::string basename) {
     if (basename.empty()) {
         basename = temp_file::create();

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -14,7 +14,7 @@
 //#define VERBOSE_DEBUG
 //#define debug_algorithms
 //#define debug_component_index
-#define debug_path_index
+//#define debug_path_index
 
 namespace xg {
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1340,7 +1340,7 @@ void XG::to_gfa(std::ostream& out) const {
 }
 
 char XG::pos_char(nid_t id, bool is_rev, size_t off) const {
-    assert(off < get_length(id));
+    assert(off < get_length(get_handle(id, false)));
     if (!is_rev) {
         size_t rank = id_to_rank(id);
         size_t pos = s_bv_select(rank) + off;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -230,6 +230,9 @@ public:
     void serialize(std::ostream& out) const;
     size_t serialize_and_measure(std::ostream& out, sdsl::structure_tree_node* s = nullptr, std::string name = "") const;
     
+    /// Dump information about the XG to the given stream for debugging
+    void dump_to_stream(std::ostream& out) const;
+    
     ////////////////////////////////////////////////////////////////////////////
     // Basic API
     ////////////////////////////////////////////////////////////////////////////

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -437,7 +437,21 @@ private:
     const static int G_EDGE_OFFSET_OFFSET = 0;
     const static int G_EDGE_TYPE_OFFSET = 1;
     const static int G_EDGE_LENGTH = 2;
+    
+    // And the edge types (so we don't confuse our magic numbers)
+    const static int EDGE_TYPE_MIN = 1;
+    const static int EDGE_TYPE_END_START = 1;
+    const static int EDGE_TYPE_END_END = 2;
+    const static int EDGE_TYPE_START_START = 3;
+    const static int EDGE_TYPE_START_END = 4;
+    const static int EDGE_TYPE_MAX = 4;
 
+    /// Compute the type of an edge given its handles.
+    /// Edge type encoding:
+    /// 1: end to start
+    /// 2: end to end
+    /// 3: start to start
+    /// 4: start to end
     int edge_type(const handle_t& from, const handle_t& to) const;
     
     /// This is a utility function for the edge exploration. It says whether we

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -14,21 +14,21 @@
 #include <sys/types.h>
 #include <dirent.h>
 
-#include "sdsl/bit_vectors.hpp"
-#include "sdsl/enc_vector.hpp"
-#include "sdsl/dac_vector.hpp"
-#include "sdsl/vlc_vector.hpp"
-#include "sdsl/wavelet_trees.hpp"
-#include "sdsl/csa_wt.hpp"
-#include "sdsl/suffix_arrays.hpp"
+#include <sdsl/bit_vectors.hpp>
+#include <sdsl/enc_vector.hpp>
+#include <sdsl/dac_vector.hpp>
+#include <sdsl/vlc_vector.hpp>
+#include <sdsl/wavelet_trees.hpp>
+#include <sdsl/csa_wt.hpp>
+#include <sdsl/suffix_arrays.hpp>
 
-#include "handlegraph/types.hpp"
-#include "handlegraph/iteratee.hpp"
-#include "handlegraph/util.hpp"
-#include "handlegraph/handle_graph.hpp"
-#include "handlegraph/path_position_handle_graph.hpp"
+#include <handlegraph/types.hpp>
+#include <handlegraph/iteratee.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_position_handle_graph.hpp>
 
-#include "mmmultimap.hpp"
+#include <mmmultimap.hpp>
 
 
 namespace xg {


### PR DESCRIPTION
This includes code that helps in understanding what's going on when we try to run xg builds on travis.

I learned that the compilation on travis seems to mangle `reinterpret_cast` and `std::min` combinations. Resolution came when I rewrote things to use `<` rather than `std::min`. @adamnovak @glennhickey 