### PR TITLE
Implement fast edge/base counting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
-  GIT_TAG "729d2c868053d2e2cbe89f9ecf46ee641235ed52"
+  GIT_TAG "7b788bfaea21d976e372b130a2353deff99757f1"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   #BUILD_COMMAND ""
   UPDATE_COMMAND ""

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2016,6 +2016,14 @@ size_t XG::get_node_count() const {
     return this->node_count;
 }
 
+size_t XG::get_edge_count() const {
+    return this->edge_count;
+}
+
+size_t XG::get_total_length() const {
+    return this->seq_length;
+}
+
 nid_t XG::min_node_id() const {
     return min_id;
 }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -271,6 +271,10 @@ public:
     virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     /// Return the number of nodes in the graph
     virtual size_t get_node_count() const;
+    /// Return the number of edges in the graph
+    virtual size_t get_edge_count() const;
+    /// Return the number of bases in the graph
+    virtual size_t get_total_length() const;
     /// Get the minimum node ID used in the graph, if any are used
     virtual nid_t min_node_id() const;
     /// Get the maximum node ID used in the graph, if any are used


### PR DESCRIPTION
This exposes the total sequence length and edge count of the graph in a sublinear way, by overriding some new optional HanldeGraph methods.