### PR TITLE
Revert to default implementation of for_each_step_position_on_handle

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1975,22 +1975,6 @@ bool XG::for_each_step_on_handle_impl(const handle_t& handle, const function<boo
     return true;
 }
 
-bool XG::for_each_step_position_on_handle(const handle_t& handle, const std::function<bool(const step_handle_t&, const bool&, const uint64_t&)>& iteratee) const {
-    size_t off = np_bv_select(id_to_rank(get_id(handle)));
-    size_t i = off;
-    while (i < np_bv.size() && (off == i && np_iv[i] != 0 || np_bv[i] == 0)) {
-        handle_t path_and_rev = as_handle(np_iv[i]);
-        step_handle_t step_handle;
-        as_integers(step_handle)[0] = number_bool_packing::unpack_number(path_and_rev);
-        as_integers(step_handle)[1] = nr_iv[i];
-        if (!iteratee(step_handle, number_bool_packing::unpack_bit(path_and_rev), nx_iv[i])) {
-            return false;
-        }
-        ++i;
-    }
-    return true;
-}
-
 /// Gets the position of a given step in the path it's from
 size_t XG::get_position_of_step(const step_handle_t& step) const {
     const auto& xgpath = *paths[as_integer(get_path_handle_of_step(step)) - 1];

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -348,8 +348,6 @@ public:
     bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
     /// Executes a function on each step of a handle in any path.
     bool for_each_step_on_handle_impl(const handle_t& handle, const std::function<bool(const step_handle_t&)>& iteratee) const;
-    /// Unpack the path position and orientation information alongside the steps
-    bool for_each_step_position_on_handle(const handle_t& handle, const std::function<bool(const step_handle_t&, const bool&, const uint64_t&)>& iteratee) const;
     /// Gets the position of a given step in the path it's from
     size_t get_position_of_step(const step_handle_t& step) const;
     /// Get the step at a given position


### PR DESCRIPTION
`xg` re-implements the non-pure-virtual handlegraph api method `for_each_step_position_on_handle()`.  But xg's version doesn't seem to work all the time.  

On this graph: https://github.com/vgteam/vg/blob/master/src/unittest/chunker.cpp#L19-L80 Querying the positions on node `4` on path `y` with this function gives `11-forward` and `36-reverse` using xg's implementation.  With the default implementation, which uses xg's own `get_step_at_position()` function, the result is `11-forward` and `31-reverse` (which is what I get when computing by hand).  When built on Mac/clang, `xg` seems to get it right though (this whole thing came up when debugging why Travis test results are different for https://github.com/vgteam/vg/pull/2506 on the Mac).

Anyway, given that `XG::for_each_step_position_on_handle()` doesn't seem more performant than the default implementation, I'm just getting rid of it, rather than worry about why it doesnt' work. 