### PR TITLE
Make XG produce unique and reasonably compact edge indexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
-  GIT_TAG "729d2c868053d2e2cbe89f9ecf46ee641235ed52"
+  GIT_TAG "7b788bfaea21d976e372b130a2353deff99757f1"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   #BUILD_COMMAND ""
   UPDATE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
-  GIT_TAG "7b788bfaea21d976e372b130a2353deff99757f1"
+  GIT_TAG "e2c45aae9a19a14176e3dc412b6ebc038385a31b"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   #BUILD_COMMAND ""
   UPDATE_COMMAND ""

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2016,6 +2016,14 @@ size_t XG::get_node_count() const {
     return this->node_count;
 }
 
+size_t XG::get_edge_count() const {
+    return this->edge_count;
+}
+
+size_t XG::get_total_length() const {
+    return this->seq_length;
+}
+
 nid_t XG::min_node_id() const {
     return min_id;
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1582,8 +1582,11 @@ size_t XG::edge_index(const edge_t& edge) const {
         throw std::runtime_error("Cound not find index of edge connecting " +
                                  std::to_string(get_id(edge.first)) + " and " + std::to_string(get_id(edge.second)));
     } else {
-        // We found it and we have the correct index
-        return idx;
+        // We found it and we have the correct index.
+        // TODO: it is 0-based, and vg pack demands 1-based indexes. So we will
+        // add 1. See
+        // https://github.com/vgteam/libhandlegraph/issues/41#issuecomment-571386849
+        return idx + 1;
     }
 }
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2088,14 +2088,19 @@ size_t XG::max_node_rank(void) const {
 }
 
 nid_t XG::node_at_vector_offset(const size_t& offset) const {
-    
+    // We expect input positions as 1-based for now.
+    // See https://github.com/vgteam/libhandlegraph/issues/41
+   
     // We have a rank primitive that gets us the 1s *before* a position.
     // We want all the bases *at or after* a 1 to give us the same value.
-    // So we get the 1s before offset + 1, which is the same as at or after offset.
-    return rank_to_id(s_bv_rank(offset + 1));
+    // So we get the 1s before (offset - 1) + 1, which is the same as at or
+    // after offset - 1, which is the 0-based version of offset.
+    return rank_to_id(s_bv_rank(offset));
 }
 
 size_t XG::node_vector_offset(const nid_t& id) const {
+    // We produce offsets as 0-based for now.
+    // See https://github.com/vgteam/libhandlegraph/issues/41
     return s_bv_select(id_to_rank(id));
 }
 

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -271,6 +271,10 @@ public:
     virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     /// Return the number of nodes in the graph
     virtual size_t get_node_count() const;
+    /// Return the number of edges in the graph
+    virtual size_t get_edge_count() const;
+    /// Return the number of bases in the graph
+    virtual size_t get_total_length() const;
     /// Get the minimum node ID used in the graph, if any are used
     virtual nid_t min_node_id() const;
     /// Get the maximum node ID used in the graph, if any are used

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -193,13 +193,19 @@ public:
     XG& operator=(const XG& other) = delete;
     XG& operator=(XG&& other) = delete;
 
-    /// build the graph from another simple graph
+    /// Build the graph from another simple graph.
+    /// The order in which nodes are enumerated becomes the XG's node order.
+    /// Note that we will get the best efficiency if the graph enumerates itself in topological order.
     void from_handle_graph(const HandleGraph& graph);
 
-    /// build the graph from another path handle graph
+    /// Build the graph from another path handle graph.
+    /// The order in which nodes are enumerated becomes the XG's node order.
+    /// Note that we will get the best efficiency if the graph enumerates itself in topological order.
     void from_path_handle_graph(const PathHandleGraph& graph);
 
-    /// Use external enumerators to drive graph construction
+    /// Use external enumerators to drive graph construction.
+    /// The order in which nodes are enumerated becomes the XG's node order.
+    /// Note that we will get the best efficiency if the graph is enumerated in topological order.
     void from_enumerators(const std::function<void(const std::function<void(const std::string& seq, const nid_t& node_id)>&)>& for_each_sequence,
                           const std::function<void(const std::function<void(const nid_t& from, const bool& from_rev,
                                                                             const nid_t& to, const bool& to_rev)>&)>& for_each_edge,


### PR DESCRIPTION
When ranking edges, we now make sure the edge ranks are unique. Previously we were not offsetting edges depending on which orientation of their owning node they came from.

This also pulls in a libhandlegraph that requires the stats methods we recently added.

