### PR TITLE
Use the vgteam fork of SDSL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/vgteam/BBHash.git
 [submodule "deps/sdsl-lite"]
 	path = deps/sdsl-lite
-	url = https://github.com/simongog/sdsl-lite.git
+	url = https://github.com/vgteam/sdsl-lite.git
 [submodule "deps/libhandlegraph"]
 	path = deps/libhandlegraph
 	url = https://github.com/vgteam/libhandlegraph.git


### PR DESCRIPTION
Switch to the [vgteam fork](https://github.com/vgteam/sdsl-lite) of SDSL. The fork will be maintained at least until [SDSL 3.0](https://github.com/xxsds/sdsl-lite) is released and we are ready to start using it.